### PR TITLE
Added credential support, updated help

### DIFF
--- a/IsilonPlatform/IsilonPlatform.psm1
+++ b/IsilonPlatform/IsilonPlatform.psm1
@@ -60,7 +60,7 @@ This variable will default to the ComputerName if not set.
     [CmdletBinding()]
     Param(
             [Parameter(Mandatory=$true,ValueFromPipelineByPropertyName=$true,ValueFromPipeline=$true,Position=0)][ValidateNotNullOrEmpty()][string] $ComputerName, 
-            [Parameter(Mandatory=$true,ValueFromPipelineByPropertyName=$true,Position=1)][PSCredential] $Credential = (Get-Credential -Message "Isilon Credential"),
+            [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true,Position=1)][PSCredential]$Credential = (Get-Credential -Message "Isilon Credential"),
             [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true,Position=2)][ValidateNotNullOrEmpty()][string]$Cluster,
             [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true,Position=3)][ValidateNotNullOrEmpty()][string]$Port='8080',
             [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true,Position=4)][switch]$default)


### PR DESCRIPTION
Hi!

Per #2, added the Credential parameter, removed Username and Password parameters, updated the comment based help, and modified the code to extract the username and password for the json.  Ran a quick test against our Isilon.

It's [generally preferred](https://twitter.com/jsnover/status/531103670415679488) to stick to Credentials, but if you have processes using this module that would break, you might want to deny this PR, or accept it and add the Username and Password params back.

If you need a way to store credentials in a script, there are ways to reasonably securely [encrypt them to disk](https://ramblingcookiemonster.wordpress.com/2014/11/27/quick-hits-credentials-and-dynamic-parameters/) using the DPAPI.

Cheers!

Warren