### PR TITLE
Improve error handling and fix uninitialized variable

### DIFF
--- a/IsilonPlatform/Functions/IsilonPlatformGet.ps1
+++ b/IsilonPlatform/Functions/IsilonPlatformGet.ps1
@@ -12863,8 +12863,8 @@ function Get-isiSmbSharev3{
 			if ($queryArguments) {
 				$queryArguments = '?' + [String]::Join('&',$queryArguments)
 			}
-			$ISIObject = Send-isiAPI -Method GET -Resource ("/platform/3/protocols/smb/shares/$parameter1" + "$queryArguments") -Cluster $Cluster
-			return $ISIObject.shares
+			$ISIObject = Send-isiAPI -Method GET -Resource ("/platform/3/protocols/smb/shares/$parameter1" + "$queryArguments") -Cluster $Cluster			
+			return $ISIObject.shares			
 	}
 	End{
 	}
@@ -13123,11 +13123,13 @@ function Get-isiQuotas{
 				$queryArguments = '?' + [String]::Join('&',$queryArguments)
 			}
 			$ISIObject = Send-isiAPI -Method GET -Resource ("/platform/1/quota/quotas" + "$queryArguments") -Cluster $Cluster
-			if ($ISIObject.PSObject.Properties['resume'] -and ($resume -or $limit)){
-				return $ISIObject.quotas,$ISIObject.resume
-			}else{
-				return $ISIObject.quotas
-			}
+			if ($ISIObject) {
+				if ($ISIObject.PSObject.Properties['resume'] -and ($resume -or $limit)){
+					return $ISIObject.quotas,$ISIObject.resume
+				}else{
+					return $ISIObject.quotas
+				}
+			}			
 	}
 	End{
 	}

--- a/IsilonPlatform/IsilonPlatform.psm1
+++ b/IsilonPlatform/IsilonPlatform.psm1
@@ -419,15 +419,16 @@ function Send-isiAPI{
         
 
     }else{
+        $ISIObject = $null
             try{
                 if ($Method -eq 'GET_JSON') {
-                    $ISIObject = (Invoke-WebRequest -Uri $url -Method GET -WebSession $session -TimeoutSec $timeout).content
+                    $ISIObject = (Invoke-WebRequest -Uri $url -Method GET -WebSession $session -TimeoutSec $timeout -UseBasicParsing).content
 
                 } elseif ( ($Method -eq 'GET') -or ($Method -eq 'DELETE') ) {
-                    $ISIObject = (Invoke-WebRequest -Uri $url -Method $Method -WebSession $session -TimeoutSec $timeout).content | ConvertFrom-Json
+                    $ISIObject = (Invoke-WebRequest -Uri $url -Method $Method -WebSession $session -TimeoutSec $timeout -UseBasicParsing).content | ConvertFrom-Json
                 
                 } elseif ( ($Method -eq 'PUT') -or ($Method -eq 'POST') ) {
-                    $ISIObject = (Invoke-WebRequest -Uri $url -Method $Method -WebSession $session -TimeoutSec $timeout -Body $body -ContentType "application/json; charset=utf-8").content | ConvertFrom-Json
+                    $ISIObject = (Invoke-WebRequest -Uri $url -Method $Method -WebSession $session -TimeoutSec $timeout -Body $body -ContentType "application/json; charset=utf-8" -UseBasicParsing).content | ConvertFrom-Json
 
                 }       
             } 


### PR DESCRIPTION
This PR fixes the following issues:

* In `Get-isiQuotas`, if a quota was not found then `ISIObject` will be `$null` and trying to reference properties of the null object will produce this error:
```powershell
The variable '$ISIObject' cannot be retrieved because it has not been set.
    + CategoryInfo          : InvalidOperation: (ISIObject:) [], CimException
    + FullyQualifiedErrorId : VariableIsUndefined,Send-isiAPI
    + PSComputerName        : localhost
```

* Modify `Send-isiAPI` to use `-UseBasicParsing` when calling `Invoke-WebRequest`. This solves the error below:
```powershell
Invoke-WebRequest : The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer’s first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.
```

