### PR TITLE
Parse as UTF-8 before sending and after receiving

### DIFF
--- a/IsilonPlatform/IsilonPlatform.psm1
+++ b/IsilonPlatform/IsilonPlatform.psm1
@@ -420,13 +420,20 @@ function Send-isiAPI{
     }else{
             try{
                 if ($Method -eq 'GET_JSON') {
-                    $ISIObject = (Invoke-WebRequest -Uri $url -Method GET -WebSession $session -TimeoutSec $timeout -UseBasicParsing).content
+                    $webResponse = Invoke-WebRequest -Uri $url -Method GET -WebSession $session -TimeoutSec $timeout -UseBasicParsing
+                    $webResponseContentEncoded = [System.Text.Encoding]::UTF8.GetString($webResponse.RawContentStream.ToArray())
+                    $ISIObject = $webResponseContentEncoded
 
                 } elseif ( ($Method -eq 'GET') -or ($Method -eq 'DELETE') ) {
-                    $ISIObject = (Invoke-WebRequest -Uri $url -Method $Method -WebSession $session -TimeoutSec $timeout -UseBasicParsing).content | ConvertFrom-Json
+                    $webResponse = Invoke-WebRequest -Uri $url -Method $Method -WebSession $session -TimeoutSec $timeout -UseBasicParsing
+                    $webResponseContentEncoded = [System.Text.Encoding]::UTF8.GetString($webResponse.RawContentStream.ToArray())
+                    $ISIObject = $webResponseContentEncoded | ConvertFrom-Json
                 
                 } elseif ( ($Method -eq 'PUT') -or ($Method -eq 'POST') ) {
-                    $ISIObject = (Invoke-WebRequest -Uri $url -Method $Method -WebSession $session -TimeoutSec $timeout -Body $body -ContentType "application/json" -UseBasicParsing).content | ConvertFrom-Json
+                    $bodyEncoded = [System.Text.Encoding]::UTF8.GetBytes($body)
+                    $webResponse = Invoke-WebRequest -Uri $url -Method $Method -WebSession $session -TimeoutSec $timeout -Body $bodyEncoded -ContentType "application/json; charset=utf-8" -UseBasicParsing
+                    $webResponseContentEncoded = [System.Text.Encoding]::UTF8.GetString($webResponse.RawContentStream.ToArray())
+                    $ISIObject = $webResponseContentEncoded | ConvertFrom-Json
 
                 }       
             } 


### PR DESCRIPTION
This addresses #16. 

The change uses/returns UTF-8 when using Invoke-WebRequest, both for the body
being sent (PUT or POST methods) and for the content received from the
server.

As the Isilon API don't return character encoding in it's headers (but
seems to be using UTF-8), the response is interpreted as something else
(ISO-8859-1? Or perhaps set by the system invoking). See [article][1].

[1]: https://stackoverflow.com/a/38699430/2670584