### PR TITLE
Support messages encapsuled in $responseBody.message

### DIFF
--- a/IsilonPlatform/IsilonPlatform.psm1
+++ b/IsilonPlatform/IsilonPlatform.psm1
@@ -436,12 +436,17 @@ function Send-isiAPI{
                     $result = $_.Exception.Response.GetResponseStream()
                     $reader = New-Object System.IO.StreamReader($result)
                     $responseBody = $reader.ReadToEnd() | ConvertFrom-Json
-                    $responeMessage = $responseBody.errors.message | Out-String
-                    Write-Error $responeMessage
+                    if ($responseBody.PSObject.Properties.name -contains "errors") {
+                        $errorResponse = $_.Exception.Message + " " + $responseBody.errors.message
+                    } elseif ($responseBody.PSObject.Properties.name -contains "message") {
+                        $errorResponse = $_.Exception.Message + " " + $responseBody.message
+                    } else {
+                        $errorResponse = $_.Exception.Message
+                    }
+                    Write-Error $errorResponse
                 } else {
                     Write-Error $_.Exception
                 }
-
             }  
         $isi_session.timeout = (Get-Date).AddSeconds($isi_session.timeout_inactive)
         $ISIObject


### PR DESCRIPTION
This addresses #18. 

In some cases the API replies with this kind of messages:

    {
      "errors": [
        {
          "code": "AEC_NOT_FOUND",
          "message": "Path not found: /404."
        }
      ]
    }

In other cases this:

    {
      "message": "nothing to update in the cluster contact info"
    }

This change ensures that both types of messages can be displayed.

It also displays the Status (code and description).

Old error:

    Send-isiAPI : The property 'errors' cannot be found on this object. Verify that the property exists.
    At IsilonPlatform\8.0.6\Functions\IsilonPlatformSet.ps1:5099 char:1
    8
    + ... ISIObject = Send-isiAPI -Method PUT -Resource "/platform/1/cluster/ow ...
    +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        + CategoryInfo          : NotSpecified: (:) [Send-isiAPI], PropertyNotFoundException
        + FullyQualifiedErrorId : PropertyNotFoundStrict,Send-isiAPI

New error:

    Send-isiAPI : The remote server returned an error: (406) Not Acceptable. nothing to update in the cluster contact info
    At Isilon-POSH\IsilonPlatform\Functions\IsilonPlatformSet.ps1:5100 char:18
    + ... ISIObject = Send-isiAPI -Method PUT -Resource "/platform/1/cluster/ow ...
    +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
        + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Send-isiAPI